### PR TITLE
add a regexp that will remove extra path data for URL routes

### DIFF
--- a/lib/services/web.js
+++ b/lib/services/web.js
@@ -100,7 +100,11 @@ WebService.prototype.setupAllRoutes = function() {
     var service = this.node.services[key];
 
     if(service.getRoutePrefix && service.setupRoutes) {
-      this.app.use('/' + this.node.services[key].getRoutePrefix(), subApp);
+      var serviceRoute = this.node.services[key].getRoutePrefix();
+      if ( typeof serviceRoute !== 'undefined') {
+        serviceRoute = serviceRoute.replace(/\@[^\/]+\//, '');
+        this.app.use('/' + serviceRoute, subApp);
+      }
       this.node.services[key].setupRoutes(subApp, express);
     } else {
       log.debug('No routes defined for: ' + key);


### PR DESCRIPTION
regexp will keep services URL path clean
e.g. @dashevo/insight-api will be accessible at insight-api